### PR TITLE
[event] Rename August sprint

### DIFF
--- a/content/pages/sprint/2021/08.rst
+++ b/content/pages/sprint/2021/08.rst
@@ -1,13 +1,13 @@
-============================================
-Scisprint 2021 End of August: solvcon devenv
-============================================
+=====================
+Scisprint 2021 August
+=====================
 
 :date: 2021-07-25 14:15
-:url: sprint/2021/08end-devenv
-:save_as: sprint/2021/08end-devenv.html
+:url: sprint/2021/08
+:save_as: sprint/2021/08.html
 
-Scisprint 2021 End of August: solvcon devenv
-============================================
+Scisprint 2021 August
+=====================
 
 We cordially invite you to join the short sprint for the development
 environment for `solvcon <https://solvcon.net/>`_ projects.  solvcon_ is a host
@@ -33,7 +33,7 @@ Registration
 ------------
 
 Please join `gather.town <https://gather.town/app/yLTe8mBDb8pogMOX/sciwork>`_
-on the day of sprint !!
+on the day of sprint!!
 
 Date & time
 -----------

--- a/content/pages/sprint/index.rst
+++ b/content/pages/sprint/index.rst
@@ -2,7 +2,7 @@
 sprint
 ======
 
-:date: 2021-05-15 10:02
+:date: 2021-07-30 21:14
 :url:
 :save_as: sprint/index.html
 
@@ -13,8 +13,7 @@ hosted by sciwork.
 Scisprint 2021
 ==============
 
-* `Scisprint 2021 End of August: solvcon devenv
-  <{filename}2021/08end-devenv.rst>`__
+* `Scisprint 2021 August <{filename}2021/08.rst>`__
 
 * `Scisprint 2021 Early July: solvcon devenv
   <{filename}2021/07early-devenv.rst>`__


### PR DESCRIPTION
This is to try to rename August sprint to include more than the single project of devenv.  If you think this is a good idea, how about merging this to your fork (which updates your https://github.com/sciwork/swportal/pull/75)?